### PR TITLE
Replace paragraph ends with a double line break

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -21,7 +21,8 @@ import(){
           | python3 -c 'print(__import__("html").unescape(__import__("sys").stdin.read()))' \
           | python3 -c 'print(__import__("html").unescape(__import__("sys").stdin.read()))' \
           | sed 's|<\s*br\s*/\?>|\n|g' \
-          | sed 's/<[^>]*>//g'  \
+          | sed 's|</p\s*>|\n\n|g' \
+          | sed 's/<[^>]*>//g' \
           | head -c 1990 )
       local postImage=$(sql $postUrl <<< 'select content from post where url = :in' \
           | grep -o 'img src="[^"]*"' \


### PR DESCRIPTION
There is currently no line break between paragraphs.

![](https://i.imgur.com/LaQQUFc.png)

This commit replaces the end paragraph tags `</p>` with a double line break, which I thought would be the simplest solution.

I have not tested the whole script in full, but I have tested the `sed` command on my copy of GNU sed.

I believe TF2 already had line breaks between paragraphs due to the presence of `<br>` between them. Hopefully this does not add too much whitespace to those posts.